### PR TITLE
Feat: Added the onAttach lifecycle hooik

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "valtio-plugin",
   "description": "Valtio state management plugin system",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "type": "module",
   "author": "Michael Sweeeney <overthemike@gmail.com>",
   "repository": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ export type ValtioPlugin = {
   
   // Lifecycle hooks
   onInit?: () => void
+  onAttach?: (proxyFactory: ProxyFactory) => void
   beforeChange?: (path: string[], value: unknown, prevValue: unknown, state: object) => undefined | boolean
   afterChange?: (path: string[], value: unknown, state: object) => void
   onSubscribe?: (proxy: object, callback: (ops: INTERNAL_Op[]) => void) => void
@@ -463,6 +464,15 @@ export function proxyInstance(): ProxyFactory {
             registry.plugins[existingIndex] = plugin
           } else {
             registry.plugins.push(plugin)
+          }
+          
+          // Call onAttach if it exists
+          if (plugin.onAttach) {
+            try {
+              plugin.onAttach(proxyFn as ProxyFactory)
+            } catch (e) {
+              console.error(`Error in plugin ${plugin.id} onAttach:`, e)
+            }
           }
         }
         


### PR DESCRIPTION
onAttach will be called when `.use` attaches the plugin to the proxyinstance and will then pass that factory back to the plugin so the plugin will have access to the factory that created it. Added docs.